### PR TITLE
Use stable gandi API url

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ func NewClient(apiKey string) *Client {
 	return &Client{apiKey}
 }
 
-const defaultBaseUrl = "https://dns.beta.gandi.net/api/v5/"
+const defaultBaseUrl = "https://dns.api.gandi.net/api/v5/"
 
 func (c Client) request(method string, urlPart string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, defaultBaseUrl+urlPart, body)


### PR DESCRIPTION
The gandi api has changed its url for a more stable
one. Although https://dns.beta.gandi.net will continue to 
work for the foreseable future, this commits updates the
url to new official one.